### PR TITLE
Critical Fix

### DIFF
--- a/util.js
+++ b/util.js
@@ -137,7 +137,8 @@ XmlStream.prototype.update = function(buf, offset, len) {
 		}
 		
 		if(this.nesting == 0) {
-			var parser = new xml2js.Parser();
+//			var parser = new xml2js.Parser();
+			var parser = new xml2js.Parser(xml2js.defaults["0.1"]);
 						
 			parser.addListener('end', function(result) {
 				self.emit('data', result);


### PR DESCRIPTION
Specify to use version 0.1 of xml2js module due to changes in how version 0.2 parses the XML into JSON which breaks existing response handlers in gtalk.js
